### PR TITLE
[cdc] add ignore-schema-change into writer_conf

### DIFF
--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/WriterConf.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/action/cdc/WriterConf.java
@@ -22,9 +22,6 @@ import org.apache.paimon.CoreOptions;
 import org.apache.paimon.options.ConfigOption;
 import org.apache.paimon.options.Options;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Collections;
@@ -68,7 +65,7 @@ public class WriterConf implements Serializable {
         this.ignoreSchemaChangeModes = getIgnoreOptions(options);
     }
 
-    public Set<IgnoreSchemaChangeMode> ignoreSchemaChangeMapping() {
+    public Set<IgnoreSchemaChangeMode> ignoreSchemaChangeModes() {
         return ignoreSchemaChangeModes;
     }
 

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/FlinkCdcSyncDatabaseSinkBuilder.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/FlinkCdcSyncDatabaseSinkBuilder.java
@@ -163,7 +163,8 @@ public class FlinkCdcSyncDatabaseSinkBuilder<T> {
                         parsed,
                         CdcDynamicTableParsingProcessFunction.DYNAMIC_SCHEMA_CHANGE_OUTPUT_TAG)
                 .keyBy(t -> t.f0)
-                .process(new MultiTableUpdatedDataFieldsProcessFunction(catalogLoader))
+                .process(
+                        new MultiTableUpdatedDataFieldsProcessFunction(catalogLoader, writerConfig))
                 .name("Schema Evolution");
 
         DataStream<CdcMultiplexRecord> partitioned =

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/MultiTableUpdatedDataFieldsProcessFunction.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/MultiTableUpdatedDataFieldsProcessFunction.java
@@ -20,6 +20,7 @@ package org.apache.paimon.flink.sink.cdc;
 
 import org.apache.paimon.catalog.Catalog;
 import org.apache.paimon.catalog.Identifier;
+import org.apache.paimon.flink.action.cdc.WriterConf;
 import org.apache.paimon.schema.SchemaChange;
 import org.apache.paimon.schema.SchemaManager;
 import org.apache.paimon.table.FileStoreTable;
@@ -53,6 +54,11 @@ public class MultiTableUpdatedDataFieldsProcessFunction
 
     public MultiTableUpdatedDataFieldsProcessFunction(Catalog.Loader catalogLoader) {
         super(catalogLoader);
+    }
+
+    public MultiTableUpdatedDataFieldsProcessFunction(
+            Catalog.Loader catalogLoader, WriterConf writerConfig) {
+        super(catalogLoader, writerConfig);
     }
 
     @Override

--- a/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/UpdatedDataFieldsProcessFunctionBase.java
+++ b/paimon-flink/paimon-flink-cdc/src/main/java/org/apache/paimon/flink/sink/cdc/UpdatedDataFieldsProcessFunctionBase.java
@@ -83,7 +83,7 @@ public abstract class UpdatedDataFieldsProcessFunctionBase<I, O> extends Process
     @Override
     public void open(Configuration parameters) {
         this.catalog = catalogLoader.load();
-        this.ignoreSchemaChangeModes = writerConfig.ignoreSchemaChangeMapping();
+        this.ignoreSchemaChangeModes = writerConfig.ignoreSchemaChangeModes();
     }
 
     protected void applySchemaChange(


### PR DESCRIPTION
### Purpose
When the Kafka CDC Synchronizing Databases with multiple writers, we expect the source table structure should be consistent.    However, in practice, some source may adjust the field types due to services, this will cause different field types to be written to the same table

For example, if someone field type of multiple sources is "string", and the field type of one source is "int", the int data cannot be written to paimon in existing Kafka CDC Synchronizing Databases Job.

### Change
By adding "ignore-schema-change" label, compatible with specified types, the above data source field compatible writes are achieved

### How to use
Add related configurations when submitting a job：
--writer_conf ignore-schema-change=int-to-string

### More detailed instructions:
int-to-string (The configuration can be bigint-to-string, smallint-to-string, int-to-string).